### PR TITLE
Fix service call command

### DIFF
--- a/homework/homework2/README.md
+++ b/homework/homework2/README.md
@@ -24,7 +24,7 @@ Your goal is to fix the errors and run ```clocon build  --packages-select buggy`
 Then, if you fixed the errors correctly, you should run ```ros2 launch buggy test.launch.py``` and run in another terminal
 
 ```
-ros2 service call /turnon "flag:            
+ros2 service call /turnon buggy/srv/CustomSrv "flag:            
   data: True"
 ```
   


### PR DESCRIPTION
Append the missing type in the service call command

## Summary by Sourcery

Documentation:
- Include missing service type 'buggy/srv/CustomSrv' in the ROS2 service call example in README